### PR TITLE
Support copying tables between Lua states

### DIFF
--- a/tests/sample.lua
+++ b/tests/sample.lua
@@ -7,10 +7,23 @@ S = rings.new ()
 data = { 12, 13, 14, }
 print (S:dostring ([[
 aux = {}
-for i, v in ipairs {...} do
+local input = ...
+for i, v in ipairs(input)  do
 	table.insert (aux, 1, v)
 end
-return unpack (aux)]], unpack (data)))
+return unpack (aux)]], data))
+
+data = { {12, 13}, {14, 15} }
+
+print (S:dostring ([[
+aux = {}
+local input = ...
+for i0, v0 in ipairs(input)  do
+   for i, v in ipairs(v0) do
+      table.insert (aux, 1, v)
+   end
+end
+return unpack (aux)]], data))
 
 S:close ()
 


### PR DESCRIPTION
Here's a patch that lets you pass tables between Lua states, as the arguments or results of dostring and friends, as long as those tables don't contain any non-transferrable objects.  The table-copying code also correctly handles recursive tables.

The table-copying code was copied from the [lua-llthreads library](https://github.com/Neopallium/lua-llthreads/), which uses similar logic to copy values between Lua states in separate threads.
